### PR TITLE
Fixed reference to cl functions first/second

### DIFF
--- a/awscli-capf.el
+++ b/awscli-capf.el
@@ -115,8 +115,8 @@ Return empty string if not present."
   (with-temp-buffer
     (insert-file-contents awscli--capf-data-file)
     (let ((all-data (read (buffer-string))))
-      (setq awscli--capf-services-info (first all-data))
-      (setq awscli--capf-global-options-info (second all-data))
+      (setq awscli--capf-services-info (cl-first all-data))
+      (setq awscli--capf-global-options-info (cl-second all-data))
       (message "awscli-capf - loaded completion data"))))
 
 (defun awscli--capf-param-strings-only (strings)


### PR DESCRIPTION
I did not have any functions named `first` and `second` and then I saw the usage of `cl-first` and `cl-second` in the file, so I figured perhaps it was miss-typed?

Thanks, looking forward to try out this package more.